### PR TITLE
Remove caching for IWebApiEndpointDispatcher and IWebApiEndpointMiddlewareExecutor

### DIFF
--- a/benchmark/Futurum.WebApiEndpoint.Benchmark.WebApiEndpoint.TestRunner/Futurum.WebApiEndpoint.Benchmark.WebApiEndpoint.TestRunner.csproj
+++ b/benchmark/Futurum.WebApiEndpoint.Benchmark.WebApiEndpoint.TestRunner/Futurum.WebApiEndpoint.Benchmark.WebApiEndpoint.TestRunner.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Futurum.Core" Version="1.0.5" />
+        <PackageReference Include="Futurum.Core" Version="1.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/sample/Futurum.WebApiEndpoint.Sample/Futurum.WebApiEndpoint.Sample.csproj
+++ b/sample/Futurum.WebApiEndpoint.Sample/Futurum.WebApiEndpoint.Sample.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Futurum.ApiEndpoint" Version="1.0.0" />
-        <PackageReference Include="Futurum.Core" Version="1.0.5" />
+        <PackageReference Include="Futurum.Core" Version="1.0.6" />
         <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />

--- a/src/Futurum.WebApiEndpoint/Futurum.WebApiEndpoint.csproj
+++ b/src/Futurum.WebApiEndpoint/Futurum.WebApiEndpoint.csproj
@@ -32,7 +32,7 @@
 
     <ItemGroup>
         <PackageReference Include="Futurum.ApiEndpoint" Version="1.0.0" />
-        <PackageReference Include="Futurum.Core" Version="1.0.5" />
+        <PackageReference Include="Futurum.Core" Version="1.0.6" />
         <PackageReference Include="FastMember" Version="1.5.0" />
         <PackageReference Include="Futurum.FluentValidation" Version="1.0.0" />
         <PackageReference Include="Futurum.Microsoft.Extensions.DependencyInjection" Version="1.0.2" />

--- a/src/Futurum.WebApiEndpoint/Internal/WebApiEndpointExecutor.cs
+++ b/src/Futurum.WebApiEndpoint/Internal/WebApiEndpointExecutor.cs
@@ -11,8 +11,7 @@ internal static class WebApiEndpointExecutor
         var routePath = ((RouteEndpoint?)endpoint)?.RoutePattern.RawText;
 
         var metadataDefinition = endpoint?.Metadata.GetMetadata<MetadataDefinition>();
-        var configuration = endpoint?.Metadata.GetMetadata<WebApiEndpointConfiguration>();
 
-        return WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, configuration, routePath, cancellationToken);
+        return WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, routePath, cancellationToken);
     }
 }

--- a/test/Futurum.WebApiEndpoint.Tests/Internal/WebApiEndpointExecutorServiceTests.cs
+++ b/test/Futurum.WebApiEndpoint.Tests/Internal/WebApiEndpointExecutorServiceTests.cs
@@ -77,7 +77,7 @@ public class WebApiEndpointExecutorServiceTests
 
         var routePath = string.Empty;
 
-        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, null, WebApiEndpointConfiguration.Default, routePath, CancellationToken.None);
+        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, null, routePath, CancellationToken.None);
 
         httpContext.Response.StatusCode.Should().Be((int)HttpStatusCode.BadRequest);
 
@@ -126,7 +126,7 @@ public class WebApiEndpointExecutorServiceTests
 
         var routePath = string.Empty;
 
-        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, WebApiEndpointConfiguration.Default, routePath, CancellationToken.None);
+        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, routePath, CancellationToken.None);
 
         httpContext.Response.StatusCode.Should().Be(metadataRouteDefinition.SuccessStatusCode);
 
@@ -175,7 +175,7 @@ public class WebApiEndpointExecutorServiceTests
 
         var routePath = string.Empty;
 
-        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, WebApiEndpointConfiguration.Default, routePath, CancellationToken.None);
+        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, routePath, CancellationToken.None);
 
         httpContext.Response.StatusCode.Should().Be(metadataRouteDefinition.FailedStatusCode);
 
@@ -214,7 +214,7 @@ public class WebApiEndpointExecutorServiceTests
 
         var routePath = string.Empty;
 
-        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, WebApiEndpointConfiguration.Default, routePath, CancellationToken.None);
+        await WebApiEndpointExecutorService.ExecuteAsync(httpContext, metadataDefinition, routePath, CancellationToken.None);
 
         httpContext.Response.StatusCode.Should().Be((int)HttpStatusCode.InternalServerError);
 


### PR DESCRIPTION
- Upgrade to latest version of Futurum.Core
- Remove caching for IWebApiEndpointDispatcher and IWebApiEndpointMiddlewareExecutor
- Fixed a couple of places that were using the wrong CancellationToken